### PR TITLE
docs: use the `Form` component instead of the html tag `form`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,11 +48,11 @@ export default function Home({ name, message }) {
   }
 
   return (
-    <form method="post" encType="multipart/form-data">
+    <Form method="post" encType="multipart/form-data">
       <input name="name" defaultValue={name} />
       <input type="file" name="file" />
       <button type="submit">{pending ? 'submitting' : 'submit'}</button>
-    </form>
+    </Form>
   );
 }
 ```

--- a/docs/content/getting-started/1-introduction.mdx
+++ b/docs/content/getting-started/1-introduction.mdx
@@ -39,11 +39,11 @@ export default function Home({ name, message }) {
   }
 
   return (
-    <form method="post" encType="multipart/form-data">
+    <Form method="post" encType="multipart/form-data">
       <input name="name" defaultValue={name} />
       <input type="file" name="file" />
       <button type="submit">{pending ? 'submitting' : 'submit'}</button>
-    </form>
+    </Form>
   );
 }
 ```


### PR DESCRIPTION
The client docs show that there is a use of the `Form` component, but the main example in README and "introduction" are using lower-cased `form`.