### PR TITLE
feat: support client side redirects in Form component

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "next-runtime",
       "version": "1.2.0",
       "license": "MIT",
       "dependencies": {
@@ -16,6 +15,7 @@
         "bytes": "^3.1.0",
         "cookies": "^0.8.0",
         "debug": "^2.6.9",
+        "node-fetch": "^2.6.2",
         "picoid": "^1.1.3"
       },
       "devDependencies": {
@@ -45,7 +45,6 @@
         "jest-playwright-preset": "^1.7.0",
         "lint-staged": "^11.1.2",
         "next": "11.1.2",
-        "node-fetch": "^2.6.2",
         "np": "^7.5.0",
         "playwright": "^1.14.1",
         "prettier": "^2.4.0",
@@ -9733,7 +9732,6 @@
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
       "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
-      "dev": true,
       "engines": {
         "node": "4.x || >=6.0.0"
       }
@@ -14865,7 +14863,8 @@
       "version": "11.1.2",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-11.1.2.tgz",
       "integrity": "sha512-hsoJmPfhVqjZ8w4IFzoo8SyECVnN+8WMnImTbTKrRUHOVJcYMmKLL7xf7T0ft00tWwAl/3f3Q3poWIN2Ueql/Q==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@next/swc-darwin-arm64": {
       "version": "11.1.2",
@@ -15580,7 +15579,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -17398,7 +17398,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -17413,7 +17414,8 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
       "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -19660,7 +19662,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-process-manager": {
       "version": "0.3.1",
@@ -21254,8 +21257,7 @@
     "node-fetch": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.2.tgz",
-      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==",
-      "dev": true
+      "integrity": "sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA=="
     },
     "node-html-parser": {
       "version": "1.4.9",
@@ -23544,7 +23546,8 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
       "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",
@@ -24373,7 +24376,8 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "bytes": "^3.1.0",
     "cookies": "^0.8.0",
     "debug": "^2.6.9",
-    "picoid": "^1.1.3"
+    "picoid": "^1.1.3",
+    "node-fetch": "^2.6.2"
   },
   "devDependencies": {
     "@testing-library/jest-dom": "^5.14.1",
@@ -63,7 +64,6 @@
     "jest-playwright-preset": "^1.7.0",
     "lint-staged": "^11.1.2",
     "next": "11.1.2",
-    "node-fetch": "^2.6.2",
     "np": "^7.5.0",
     "playwright": "^1.14.1",
     "prettier": "^2.4.0",

--- a/pages/client-redirect/client-redirect.test.ts
+++ b/pages/client-redirect/client-redirect.test.ts
@@ -1,0 +1,10 @@
+export {};
+
+test('client redirect', async () => {
+  await page.goto('http://localhost:4000/client-redirect/start');
+
+  expect(page.url()).toMatch('/client-redirect/start');
+  await page.click('button[type=submit]');
+  await page.waitForURL('http://localhost:4000/client-redirect/destination');
+  expect(await page.textContent('p')).toBe('The redirect has landed. 🚀');
+});

--- a/pages/client-redirect/destination.tsx
+++ b/pages/client-redirect/destination.tsx
@@ -1,0 +1,13 @@
+import { handle, json } from '../../src';
+
+export const getServerSideProps = handle({
+  get: async () => {
+    return json({
+      message: 'The redirect has landed. 🚀',
+    });
+  },
+});
+
+export default function ClientRedirect({ message }: { message: string }) {
+  return <p>{message}</p>;
+}

--- a/pages/client-redirect/start.tsx
+++ b/pages/client-redirect/start.tsx
@@ -1,0 +1,20 @@
+import { handle, json, redirect } from '../../src';
+import { Form } from '../../src/form';
+
+export const getServerSideProps = handle({
+  get: () => {
+    return json({});
+  },
+  patch: async () => {
+    return redirect('/client-redirect/destination', { status: 303 });
+  },
+});
+
+export default function ClientRedirect() {
+  return (
+    <Form method="patch">
+      <input type="hidden" name="redirectStatus" value="303" />
+      <button type="submit">Submit</button>
+    </Form>
+  );
+}

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -7,7 +7,6 @@ import {
   useEffect,
   useReducer,
   useRef,
-  useState,
 } from 'react';
 
 import {
@@ -16,6 +15,7 @@ import {
   HttpMethodWithBody,
 } from './http-methods';
 import { useRefs } from './utils/useRefs';
+import { useSafeState } from './utils/useSafeState';
 
 type Store = {
   pending: number;
@@ -79,48 +79,42 @@ type FetchDataOptions = {
   data: FormData;
 };
 
-async function fetchData({ method: methodArg, url, data }: FetchDataOptions) {
-  const getFetchResponse = (): Promise<Response> => {
-    const method = methodArg.toLowerCase() as Lowercase<HttpMethod>;
+async function fetchData({
+  method: methodArg,
+  url,
+  data,
+}: FetchDataOptions): Promise<Response> {
+  const method = methodArg.toLowerCase() as Lowercase<HttpMethod>;
 
-    if (method === 'get') {
-      const _url = new URL(url);
+  if (method === 'get') {
+    const _url = new URL(url);
 
-      for (const [field, value] of data.entries()) {
-        if (typeof value === 'string') {
-          _url.searchParams.set(field, value);
-        } else {
-          throw new Error('Cannot submit binary form data using GET');
-        }
+    for (const [field, value] of data.entries()) {
+      if (typeof value === 'string') {
+        _url.searchParams.set(field, value);
+      } else {
+        throw new Error('Cannot submit binary form data using GET');
       }
-
-      history.replaceState(null, null, url);
-
-      return fetch(_url.toString(), {
-        method: 'get',
-        headers: { accept: 'application/json' },
-      });
     }
 
-    if (httpMethodsWithBody.includes(method as HttpMethodWithBody)) {
-      return fetch(url, {
-        // patch must be in all caps: https://github.com/github/fetch/issues/254
-        method: method.toUpperCase(),
-        headers: { accept: 'application/json' },
-        body: data,
-      });
-    }
+    history.replaceState(null, null, url);
 
-    throw Error('unsupported form method');
-  };
-
-  const response = await getFetchResponse();
-
-  if (response.status >= 300) {
-    throw new Error(`[${response.status}]: ${response.statusText}`);
+    return fetch(_url.toString(), {
+      method: 'get',
+      headers: { accept: 'application/json' },
+    });
   }
 
-  return response.json();
+  if (httpMethodsWithBody.includes(method as HttpMethodWithBody)) {
+    return fetch(url, {
+      // patch must be in all caps: https://github.com/github/fetch/issues/254
+      method: method.toUpperCase(),
+      headers: { accept: 'application/json' },
+      body: data,
+    });
+  }
+
+  throw Error('unsupported form method');
 }
 
 export type FormProps = {
@@ -179,12 +173,14 @@ export const Form = forwardRef(function Form(
   }: FormProps,
   forwardRef,
 ) {
-  const [state, setState] = useState<
+  type FormState =
     | { state: 'idle'; error?: string; data?: unknown }
     | { state: 'pending'; data: FetchDataOptions }
     | { state: 'success'; data: Record<string, unknown> }
-    | { state: 'error'; data?: unknown; error: string }
-  >({ state: 'idle' });
+    | { state: 'redirect'; url: string }
+    | { state: 'error'; data?: unknown; error: string };
+
+  const [state, setState] = useSafeState<FormState>({ state: 'idle' });
 
   const router = useRouter();
   const ref = useRefs<HTMLFormElement>(forwardRef);
@@ -194,15 +190,17 @@ export const Form = forwardRef(function Form(
   handlers.current.onSuccess = onSuccess;
 
   useEffect(() => {
-    if (!shallow && state.state === 'success') {
+    if (shallow) return;
+    if (state.state === 'success') {
       // router is undefined in tests
       void router?.replace(router.asPath, undefined, { scroll: false });
+    }
+    if (state.state === 'redirect') {
+      void router?.push(state.url, undefined, { scroll: false });
     }
   }, [state.state, shallow]);
 
   useEffect(() => {
-    let mounted = true;
-
     async function transition() {
       switch (state.state) {
         case 'pending': {
@@ -212,11 +210,28 @@ export const Form = forwardRef(function Form(
           });
 
           try {
-            const result = await fetchData(state.data);
-            if (!mounted) return;
-            setState({ ...state, state: 'success', data: result });
+            const response = await fetchData(state.data);
+
+            if (response.redirected) {
+              setState({
+                state: 'redirect',
+                url: response.url,
+              });
+            } else if (response.ok) {
+              setState({
+                ...state,
+                state: 'success',
+                data: await response.json(),
+              });
+            } else {
+              setState({
+                ...state,
+                state: 'error',
+                data: await response.json(),
+                error: `[${response.status}]: ${response.statusText}`,
+              });
+            }
           } catch (e) {
-            if (!mounted) return;
             setState({ ...state, state: 'error', error: e.message });
           } finally {
             submission.done();
@@ -243,10 +258,6 @@ export const Form = forwardRef(function Form(
     }
 
     void transition();
-
-    return () => {
-      mounted = false;
-    };
   }, [state]);
 
   const handleSubmit = async (event) => {

--- a/src/utils/useSafeState.ts
+++ b/src/utils/useSafeState.ts
@@ -1,0 +1,23 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+/**
+ * Sets state while avoiding the "set state while unmounted" warning,
+ * can eventually be removed in react 18 (hopefully!)
+ */
+export function useSafeState<T>(initial: T) {
+  const [state, setState] = useState(initial);
+  const mounted = useRef(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => {
+      mounted.current = false;
+    };
+  }, []);
+
+  const setStateIfMounted = useCallback((value: T) => {
+    if (mounted.current) setState(value);
+  }, []);
+
+  return [state, setStateIfMounted] as const;
+}


### PR DESCRIPTION
This PR makes it so the `<Form>` will perform a `router.push` if a redirect is returned from a server-side handler. Example from tests:

```ts
export const getServerSideProps = handle({
  get: () => {
    return json({});
  },
  patch: async () => {
    return redirect('/client-redirect/destination', { status: 303 });
  },
});

export default function ClientRedirect() {
  return (
    <Form method="patch">
      <input type="hidden" name="redirectStatus" value="303" />
      <button type="submit">Submit</button>
    </Form>
  );
}
```
```ts
// destination
export const getServerSideProps = handle({
  get: async () => {
    return json({
      message: 'The redirect has landed. 🚀',
    });
  },
});

export default function ClientRedirect({ message }: { message: string }) {
  return <p>{message}</p>;
}

```

Open to changes on how this should work, or if this just isn't a good idea 😅 Mostly just hacked it in to see if / how well it would work