### PR TITLE
feat: include response data in error

### DIFF
--- a/docs/content/api/form.mdx
+++ b/docs/content/api/form.mdx
@@ -53,11 +53,19 @@ function MyPage() {
   the page or invoke a redirect. `response` the json payload returned from the
   `post` handler.
 
-- **onError** _(error: string) => void_
+- **onError** _(error: { code: string | number, message: string, { [key:
+  string]: unknown }) => void_
 
   A callback that's invoked when the form errors on the server side. Can be used
-  to show an error message. `error` is a string containing statusCode &
-  statusText
+  to show an error message.
+
+  If the error originates from the server, code will default to
+  `response.status`, and message to `response.statusText`. The error object gets
+  merged with the json returned from the server. So the defaults can be
+  overwritten.
+
+  If the error originates from the client, code will be `Error.name`, and
+  message the `Error.message`.
 
 - **shallow** _boolean_
 

--- a/src/form.tsx
+++ b/src/form.tsx
@@ -155,9 +155,9 @@ export type FormProps = {
    * The fields & content of the form. Make something pretty :-)
    */
   children: ReactNode;
-} & FormHTMLAttributes<HTMLFormElement>;
+} & Omit<FormHTMLAttributes<HTMLFormElement>, 'onError' | 'onSubmit'>;
 
-type FormError = {
+export type FormError = {
   code: string | number;
   message: string;
 };
@@ -216,12 +216,17 @@ export const Form = forwardRef(function Form(
 
           try {
             const response = await fetchData(state.data);
+            const isJson = response.headers
+              .get('content-type')
+              .startsWith('application/json');
+
+            const data = isJson ? await response.json() : undefined;
 
             if (response.ok) {
               setState({
                 ...state,
                 state: 'success',
-                data: await response.json(),
+                data,
                 redirect: response.redirected ? response.url : undefined,
               });
             } else {
@@ -231,7 +236,7 @@ export const Form = forwardRef(function Form(
                 error: {
                   code: response.status,
                   message: response.statusText,
-                  ...(await response.json()),
+                  ...data,
                 },
               });
             }


### PR DESCRIPTION
Improved the `onError` callback, so that response data can be consumed:

- **onError** _(error: { code: string | number, message: string, { [key: string]: unknown }) => void_

  A callback that's invoked when the form errors on the server side. Can be used to show an error message.

  If the error originates from the server, code will default to `response.status`, and message to `response.statusText`. The error object gets merged with the json returned from the server. So the defaults can be overwritten.

  If the error originates from the client, code will be `Error.name`, and message the `Error.message`.

---

resolves #19