### PR TITLE
feat: support Response throwing

### DIFF
--- a/pages/response-throwing.test.ts
+++ b/pages/response-throwing.test.ts
@@ -1,0 +1,9 @@
+export {};
+
+test('thrown response helpers are caught and used as response', async () => {
+  await page.goto('http://localhost:4000/response-throwing');
+
+  expect(page.url()).toMatch('/response-throwing');
+  await page.click('button[type=submit]');
+  await page.waitForURL('http://localhost:4000/login');
+});

--- a/pages/response-throwing.tsx
+++ b/pages/response-throwing.tsx
@@ -1,0 +1,38 @@
+import { setTimeout } from 'node:timers/promises';
+
+import { handle, json, redirect } from '../src';
+import { Form, useFormSubmit } from '../src/form';
+
+const toggle = false;
+
+function isAuthenticated<T>(
+  request: T,
+): asserts request is T & { user: Record<string, string> } {
+  if (!('user' in request)) {
+    throw redirect('/login', 303);
+  }
+}
+
+export const getServerSideProps = handle({
+  async get() {
+    await setTimeout(1000);
+    return json({ toggle });
+  },
+
+  async post({ req }) {
+    isAuthenticated(req);
+
+    return json(req.user, 303) as any;
+  },
+});
+
+export default function Toggle({ toggle }: { toggle: boolean }) {
+  return (
+    <main>
+      <p>submitting this form should result in a redirect</p>
+      <Form method="post">
+        <button type="submit">submit</button>
+      </Form>
+    </main>
+  );
+}


### PR DESCRIPTION
This change allows one to throw responses, instead of returning them. This enables us to break out of the response pipeline without creating a `pyramid of death` or tons of `if not, return` statements.

For example, the following snippet should look familiar:

```ts
export const getServerSideProps = handle({
  async get({ req, params }) {
    const user = await getUserFromRequest(req)
    if (!user) {
      return redirect("/login")
    }

    if (!params?.bucketId) {
      return notFound()
    }

    // the real work
    return json(...
```

With this change, we turn that into:

```ts
export const getServerSideProps = handle({
  async get({ req, params }) {
    assertIsAuthenticated(req);
    assertBucketId(params);

    // the real work
    return json(...
  }
});
```

That function uses the assertion functions from below. When looking at those, you might think that you're better off with the conditions in the first version (typescript adds some noise here), but remember that these utils are reusable. Write them once, add use them in all your API handlers.

Besides, the assertion directly narrows down the types. Before `assertIsAuthenticated`, `req.user` doesn't exist. After the check, it's typed to `Record<string, string>`. Read [more here](https://dev.to/smeijer/typescript-type-assertions-4klf) if you're unfamiliar with those.

```ts
function assertIsAuthenticated<T>(request: T): asserts request is T & { user: Record<string, string> } {
  if (!('user' in request)) {
    throw redirect('/login', 303);
  }
}

function assertBucketId<T>(params: T): asserts params is T & { bucketId: string } {
  if (typeof params['bucketId'] !== 'string') {
    throw notFound();
  }
}
```