### PR TITLE
fix: Next 12 support

### DIFF
--- a/src/handle.ts
+++ b/src/handle.ts
@@ -184,8 +184,7 @@ export function handle<
     const propResult = applyResponse(response, context.res, accept);
 
     if ('redirect' in propResult) {
-      context.res.end();
-      return VOID_NEXT_RESPONSE;
+      return propResult;
     }
 
     // Note, we can't make this api first. That will break shallow rerender

--- a/src/responses.ts
+++ b/src/responses.ts
@@ -5,6 +5,7 @@ import {
   NotFoundResult,
   PropResult,
   RedirectResult,
+  RedirectStatusCode,
 } from './types/next';
 
 export type ResponseInit = {
@@ -49,8 +50,8 @@ export function redirect(
     responseInit = { status: 302, ...init };
   }
 
-  const permanent = responseInit.status === 301 || responseInit.status === 308;
-  const body: RedirectResult = { redirect: { destination, permanent } };
+  const statusCode = (responseInit.status || 302) as RedirectStatusCode;
+  const body: RedirectResult = { redirect: { destination, statusCode } };
 
   const headers = mergeHeaders(responseInit.headers, {
     location: destination,

--- a/src/types/next.ts
+++ b/src/types/next.ts
@@ -2,9 +2,11 @@ import { IncomingMessage, ServerResponse } from 'http';
 
 import { ParsedUrlQuery } from './querystring';
 
+export type RedirectStatusCode = 301 | 302 | 303 | 307 | 308;
+
 export type Redirect =
   | {
-      statusCode: 301 | 302 | 303 | 307 | 308;
+      statusCode: RedirectStatusCode;
       destination: string;
       basePath?: false;
     }


### PR DESCRIPTION
Next 12 is currently unsupported. The main thing that seems to be breaking, is calling `res.end()` or `res.write()` in getServerSideProps, as shown in this [basic reproduction](https://codesandbox.io/s/next-12-gssp-pyy0q?file=/pages/index.js)

Current state:

- `redirect` has been fixed
- `json` response is still broken