### PR TITLE
feat: include button name=value in submitted formdata

### DIFF
--- a/pages/form-with-named-buttons.test.ts
+++ b/pages/form-with-named-buttons.test.ts
@@ -1,0 +1,59 @@
+import { Request } from 'playwright';
+
+const methodPredicate = (method: string) => {
+  return (req: Request) =>
+    req.url() === page.url() &&
+    req.method().toLowerCase() === method.toLowerCase();
+};
+
+test('submit buttons can override form method', async () => {
+  await page.goto(`http://localhost:4000/form-with-named-buttons`);
+
+  // click create button
+  await page.click('button[value="create"]');
+  await page.waitForEvent('response');
+  expect(await page.textContent('#message')).toBe('created via post request');
+  expect(await page.$('#error')).toBe(null);
+
+  // click delete button
+  await page.click('button[value="delete"]');
+  await page.waitForEvent('response');
+  expect(await page.textContent('#message')).toBe('deleted via delete request');
+  expect(await page.$('#error')).toBe(null);
+});
+
+test('submit buttons name is added to form data', async () => {
+  await page.goto(`http://localhost:4000/form-with-named-buttons`);
+
+  const postRequest = page.waitForEvent('request', methodPredicate('post'));
+  await page.click(`button[value="create"]`);
+
+  const postResponse = await postRequest
+    .then((req) => req.response())
+    .then((x) => x?.json());
+
+  expect(postResponse).toEqual({
+    message: `created via post request`,
+    values: {
+      id: 'abc',
+      action: 'create',
+    },
+  });
+
+  const deleteRequest = page.waitForEvent('request', methodPredicate('delete'));
+  await page.click(`button[value="delete"]`);
+
+  const deleteResponse = await deleteRequest
+    .then((req) => req.response())
+    .then((x) => x?.json());
+
+  expect(deleteResponse).toEqual({
+    message: `deleted via delete request`,
+    values: {
+      id: 'abc',
+      action: 'delete',
+    },
+  });
+});
+
+export {};

--- a/pages/form-with-named-buttons.tsx
+++ b/pages/form-with-named-buttons.tsx
@@ -1,0 +1,40 @@
+import { handle, json } from '../src';
+import { Form, useFormSubmit } from '../src/form';
+
+type PageProps = { message?: string };
+
+export const getServerSideProps = handle<PageProps>({
+  async get() {
+    return json({});
+  },
+
+  async post({ req: { body } }) {
+    return json({ message: 'created via post request', values: body });
+  },
+
+  async delete({ req: { body } }) {
+    return json({ message: 'deleted via delete request', values: body });
+  },
+});
+
+export default function FormWithAction() {
+  const { data, error } = useFormSubmit<PageProps>();
+
+  return (
+    <>
+      {error ? <p id="error">{error.message}</p> : null}
+      <p id="message">{data?.message}</p>
+      <Form method="post">
+        <input type="hidden" name="id" value="abc" />
+
+        <button name="action" value="create" type="submit" formMethod="post">
+          Create
+        </button>
+
+        <button name="action" value="delete" type="submit" formMethod="delete">
+          Delete
+        </button>
+      </Form>
+    </>
+  );
+}

--- a/src/form/dom.ts
+++ b/src/form/dom.ts
@@ -1,0 +1,42 @@
+import { BaseSyntheticEvent, FormEvent } from 'react';
+
+export function isHtmlElement(object: any): object is HTMLElement {
+  return object != null && typeof object.tagName === 'string';
+}
+
+export function isButtonElement(object: any): object is HTMLButtonElement {
+  return isHtmlElement(object) && object.tagName.toLowerCase() === 'button';
+}
+
+export function isFormElement(object: any): object is HTMLFormElement {
+  return isHtmlElement(object) && object.tagName.toLowerCase() === 'form';
+}
+
+export function isInputElement(object: any): object is HTMLInputElement {
+  return isHtmlElement(object) && object.tagName.toLowerCase() === 'input';
+}
+
+export type HTMLSubmitEvent = BaseSyntheticEvent<
+  SubmitEvent,
+  Event,
+  HTMLFormElement
+>;
+
+export type HTMLFormSubmitter = HTMLButtonElement | HTMLInputElement;
+
+export function getFormSubmitter(event: FormEvent<HTMLFormElement>) {
+  return (event as unknown as HTMLSubmitEvent).nativeEvent.submitter as
+    | HTMLButtonElement
+    | HTMLInputElement
+    | null;
+}
+
+export function isValidFormSubmitter(
+  submitter: HTMLButtonElement | HTMLInputElement,
+) {
+  return (
+    isButtonElement(submitter) ||
+    (isInputElement(submitter) &&
+      (submitter.type === 'submit' || submitter.type === 'image'))
+  );
+}

--- a/src/form/form.tsx
+++ b/src/form/form.tsx
@@ -1,8 +1,22 @@
 import { useRouter } from 'next/router';
-import { FormEventHandler, FormHTMLAttributes, forwardRef } from 'react';
+import {
+  BaseSyntheticEvent,
+  FormEvent,
+  FormEventHandler,
+  FormHTMLAttributes,
+  forwardRef,
+  useCallback,
+} from 'react';
 
 import { HttpMethod } from '../http-methods';
 import { useLatestRef } from '../lib/use-latest-ref';
+import {
+  getFormSubmitter,
+  isButtonElement,
+  isFormElement,
+  isInputElement,
+  isValidFormSubmitter,
+} from './dom';
 import { FormStateWithHelpers } from './helpers';
 import { useFormStoreSubmit } from './store';
 
@@ -39,7 +53,15 @@ export type FormProps<Data> = {
 >;
 
 function FormComponent<Data>(
-  { method = 'post', onSubmit, onSuccess, onError, ...props }: FormProps<Data>,
+  {
+    method,
+    action,
+    encType,
+    onSubmit,
+    onSuccess,
+    onError,
+    ...props
+  }: FormProps<Data>,
   ref: React.Ref<HTMLFormElement>,
 ) {
   const submit = useFormStoreSubmit();
@@ -47,32 +69,88 @@ function FormComponent<Data>(
   const onSuccessRef = useLatestRef(onSuccess);
   const onErrorRef = useLatestRef(onError);
 
-  const handleSubmit: FormEventHandler<HTMLFormElement> = async (event) => {
-    onSubmit?.(event);
-    if (event.defaultPrevented) return;
+  const handleSubmit: FormEventHandler<HTMLFormElement> = useCallback(
+    async (event) => {
+      onSubmit?.(event);
+      if (event.defaultPrevented) return;
 
-    event.preventDefault();
+      event.preventDefault();
 
-    submit({
-      name: props.name,
-      router,
-      formData: new FormData(event.currentTarget),
-      formAction: props.action || location.href.split('?')[0],
+      // <button>/<input type="submit"> may override attributes of <form>
+      const submitter = getFormSubmitter(event);
+      const form = submitter ? submitter.form : event.currentTarget;
+
+      if (!form) {
+        throw new Error('Cannot submit a <button> without a <form>');
+      }
+
+      if (submitter && !isValidFormSubmitter(submitter)) {
+        throw new Error(
+          'Cannot submit element that is not <form>, <button>, or <input type="submit|image">',
+        );
+      }
+
+      const formData: FormData = new FormData(form);
+
+      const formMethod =
+        (submitter?.getAttribute('formmethod') as HttpMethod) ||
+        (form.getAttribute('method') as HttpMethod) ||
+        method ||
+        'post';
+
+      const formAction =
+        (submitter?.getAttribute('formaction') as HttpMethod) ||
+        (form.getAttribute('action') as HttpMethod) ||
+        action ||
+        location.href.split('?')[0];
+
+      // Include name + value from the submitter
+      if (submitter?.name) {
+        formData.set(submitter.name, submitter.value);
+      }
+
+      console.log('submit', formData, formAction, formMethod);
+      submit({
+        name: props.name,
+        router,
+        formData,
+        formAction,
+        method: formMethod,
+
+        // need to wrap the callbacks like this so the latest ref value is accessed
+        // at the time the callbacks are invoked, otherwise we could pass in a stale callback
+        onError: (state) => {
+          console.log('err', state);
+          onErrorRef.current?.(state as FormStateWithHelpers<Data>);
+        },
+        onSuccess: (state) => {
+          console.log('done');
+          onSuccessRef.current?.(state as FormStateWithHelpers<Data>);
+        },
+      });
+    },
+    [
       method,
+      onErrorRef,
+      onSubmit,
+      onSuccessRef,
+      action,
+      props.name,
+      router,
+      submit,
+    ],
+  );
 
-      // need to wrap the callbacks like this so the latest ref value is accessed
-      // at the time the callbacks are invoked,
-      // otherwise we could pass in a stale callback
-      onError: (state) => {
-        onErrorRef.current?.(state as FormStateWithHelpers<Data>);
-      },
-      onSuccess: (state) => {
-        onSuccessRef.current?.(state as FormStateWithHelpers<Data>);
-      },
-    });
-  };
-
-  return <form {...props} ref={ref} method={method} onSubmit={handleSubmit} />;
+  return (
+    <form
+      {...props}
+      ref={ref}
+      action={action}
+      encType={encType}
+      method={method}
+      onSubmit={handleSubmit}
+    />
+  );
 }
 
 /**


### PR DESCRIPTION
The name and value of the button that triggered the form submit, are now included in the payload.

This enables us to handle multiple forms/actions on a single route.

```tsx
import { handle, json } from "next-runtime";
import { Form, useFormSubmit } from "next-runtime/form";

export const getServerSideProps = handle({
  async get() {
    return json({});
  },

  async post({ req: { body: { action, ...values } } }) {
    switch (action) {
      case "like": return handleLike(values);
      case "bookmark": return handleBookmark(values);
      default: throw new Error("unsupported action");
    }
  },
});

export default function Page() {
  return (
    <Form method="post">
      <input type="hidden" name="id" value="abc" />

      <button name="action" value="like" type="submit">
        ❤️
      </button>

      <button name="action" value="bookmark" type="submit">
        🔖
      </button>
    </Form>
  );
}

```

---

fixes #60.

