### PR TITLE
chore: upgrade busboy to 1.6.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "next-runtime",
-  "version": "2.4.2",
+  "version": "2.4.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-runtime",
-      "version": "2.4.2",
+      "version": "2.4.1",
       "license": "MIT",
       "dependencies": {
         "@types/accepts": "^1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,19 +1,19 @@
 {
   "name": "next-runtime",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "next-runtime",
-      "version": "2.4.1",
+      "version": "2.4.2",
       "license": "MIT",
       "dependencies": {
         "@types/accepts": "^1",
         "@types/body-parser": "^1",
-        "@types/busboy": "^0",
+        "@types/busboy": "^1.5.4",
         "@types/bytes": "^3",
-        "@types/cookies": "^0",
+        "@types/cookies": "^0.7",
         "@types/debug": "^4",
         "@types/node-fetch": "^2",
         "@types/react": "^17",
@@ -21,7 +21,7 @@
         "accepts": "^1.3.7",
         "attr-accept": "^2.2.2",
         "body-parser": "^1.19.0",
-        "busboy": "^0.2.14",
+        "busboy": "^1.6.0",
         "bytes": "^3.1.0",
         "cookies": "^0.8.0",
         "debug": "^2.6.9",
@@ -35,7 +35,6 @@
         "@testing-library/react": "^12.1.0",
         "@testing-library/user-event": "^13.2.1",
         "@types/accepts": "^1.3.5",
-        "@types/busboy": "^0.2.4",
         "@types/bytes": "^3.1.1",
         "@types/cookies": "^0.7.7",
         "@types/cors": "^2.8.12",
@@ -1844,10 +1843,10 @@
       }
     },
     "node_modules/@types/busboy": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.2.4.tgz",
-      "integrity": "sha512-f+ZCVjlcN8JW/zf3iR0GqO4gjOUlltMTtZjn+YR1mlK+MVu6esTiIecO0/GQlmYQPQLdBnc7+5vG3Xb+SkvFLw==",
-      "dev": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*"
       }
@@ -3282,15 +3281,14 @@
       "dev": true
     },
     "node_modules/busboy": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "dependencies": {
-        "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "streamsearch": "^1.1.0"
       },
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10.16.0"
       }
     },
     "node_modules/bytes": {
@@ -3754,11 +3752,6 @@
         "url": "https://opencollective.com/core-js"
       }
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "node_modules/cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -4195,18 +4188,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/dicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
-      "dependencies": {
-        "readable-stream": "1.1.x",
-        "streamsearch": "0.1.2"
-      },
-      "engines": {
-        "node": ">=0.8.0"
       }
     },
     "node_modules/diff-sequences": {
@@ -6341,7 +6322,8 @@
     "node_modules/inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "node_modules/ini": {
       "version": "1.3.7",
@@ -7173,11 +7155,6 @@
       "resolved": "https://registry.npmjs.org/is-yarn-global/-/is-yarn-global-0.3.0.tgz",
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
-    },
-    "node_modules/isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -8291,7 +8268,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/js-yaml": {
       "version": "3.14.1",
@@ -9256,7 +9233,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       },
@@ -10277,7 +10254,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -11565,7 +11542,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -11679,22 +11656,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "dependencies": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      }
-    },
-    "node_modules/readable-stream/node_modules/string_decoder": {
-      "version": "0.10.31",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-      "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
     },
     "node_modules/readdirp": {
       "version": "3.5.0",
@@ -12394,11 +12355,11 @@
       }
     },
     "node_modules/streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
       "engines": {
-        "node": ">=0.8.0"
+        "node": ">=10.0.0"
       }
     },
     "node_modules/string_decoder": {
@@ -14811,7 +14772,8 @@
       "version": "12.0.3",
       "resolved": "https://registry.npmjs.org/@next/react-refresh-utils/-/react-refresh-utils-12.0.3.tgz",
       "integrity": "sha512-YPtlfvkYh/4MvNNm5w3uwo+1KPMg67snzr5CuexbRewsu2ITaF7f0bh0Jcayi20wztk8SgWjNz1bmF8j9qbWIw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "@next/swc-android-arm64": {
       "version": "12.0.3",
@@ -15123,10 +15085,9 @@
       }
     },
     "@types/busboy": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-0.2.4.tgz",
-      "integrity": "sha512-f+ZCVjlcN8JW/zf3iR0GqO4gjOUlltMTtZjn+YR1mlK+MVu6esTiIecO0/GQlmYQPQLdBnc7+5vG3Xb+SkvFLw==",
-      "dev": true,
+      "version": "1.5.4",
+      "resolved": "https://registry.npmjs.org/@types/busboy/-/busboy-1.5.4.tgz",
+      "integrity": "sha512-kG7WrUuAKK0NoyxfQHsVE6j1m01s6kMma64E+OZenQABMQyTJop1DumUWcLwAQ2JzpefU7PDYoRDKl8uZosFjw==",
       "requires": {
         "@types/node": "*"
       }
@@ -15656,7 +15617,8 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -16269,12 +16231,11 @@
       "dev": true
     },
     "busboy": {
-      "version": "0.2.14",
-      "resolved": "https://registry.npmjs.org/busboy/-/busboy-0.2.14.tgz",
-      "integrity": "sha1-bCpiLvz0fFe7vh4qnDetNseSVFM=",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
       "requires": {
-        "dicer": "0.2.5",
-        "readable-stream": "1.1.x"
+        "streamsearch": "^1.1.0"
       }
     },
     "bytes": {
@@ -16638,11 +16599,6 @@
       "integrity": "sha512-kmW/k8MaSuqpvA1xm2l3TVlBuvW+XBkcaOroFUpO3D4lsTGQWBTb/tBDCf/PNkkPLrwgrkQRIYNPB0CeqGJWGQ==",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
-      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
-    },
     "cors": {
       "version": "2.8.5",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
@@ -16994,15 +16950,6 @@
       "resolved": "https://registry.npmjs.org/detect-newline/-/detect-newline-3.1.0.tgz",
       "integrity": "sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==",
       "dev": true
-    },
-    "dicer": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/dicer/-/dicer-0.2.5.tgz",
-      "integrity": "sha1-WZbAhrszIYyBLAkL3cCc0S+stw8=",
-      "requires": {
-        "readable-stream": "1.1.x",
-        "streamsearch": "0.1.2"
-      }
     },
     "diff-sequences": {
       "version": "27.0.6",
@@ -17436,7 +17383,8 @@
       "version": "8.3.0",
       "resolved": "https://registry.npmjs.org/eslint-config-prettier/-/eslint-config-prettier-8.3.0.tgz",
       "integrity": "sha512-BgZuLUSeKzvlL/VUjx/Yb787VQ26RU3gGjA3iiFvdsp/2bMfVIWUVP7tjxtjS0e+HP409cPlPvNkQloz8C91ew==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-prettier": {
       "version": "4.0.0",
@@ -17451,13 +17399,15 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.2.0.tgz",
       "integrity": "sha512-623WEiZJqxR7VdxFCKLI6d6LLpwJkGPYKODnkH3D7WpOG5KM8yWueBd8TLsNAetEJNF5iJmolaAKO3F8yzyVBQ==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-plugin-simple-import-sort": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-simple-import-sort/-/eslint-plugin-simple-import-sort-7.0.0.tgz",
       "integrity": "sha512-U3vEDB5zhYPNfxT5TYR7u01dboFZp+HNpnGhkDB2g/2E4wZ/g1Q9Ton8UwCLfRV9yAKyYqDh62oHOamvkFxsvw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -18579,7 +18529,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.7",
@@ -19179,11 +19130,6 @@
       "integrity": "sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==",
       "dev": true
     },
-    "isarray": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
-      "integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
-    },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
@@ -19703,7 +19649,8 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "jest-process-manager": {
       "version": "0.3.1",
@@ -20055,7 +20002,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true
+      "devOptional": true
     },
     "js-yaml": {
       "version": "3.14.1",
@@ -20800,7 +20747,7 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
       "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "js-tokens": "^3.0.0 || ^4.0.0"
       }
@@ -21602,7 +21549,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-      "dev": true
+      "devOptional": true
     },
     "object-inspect": {
       "version": "1.11.0",
@@ -22567,7 +22514,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -22656,24 +22603,6 @@
           "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.8.1.tgz",
           "integrity": "sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==",
           "dev": true
-        }
-      }
-    },
-    "readable-stream": {
-      "version": "1.1.14",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz",
-      "integrity": "sha1-fPTFTvZI44EwhMY23SB54WbAgdk=",
-      "requires": {
-        "core-util-is": "~1.0.0",
-        "inherits": "~2.0.1",
-        "isarray": "0.0.1",
-        "string_decoder": "~0.10.x"
-      },
-      "dependencies": {
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
         }
       }
     },
@@ -23236,9 +23165,9 @@
       }
     },
     "streamsearch": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-0.1.2.tgz",
-      "integrity": "sha1-gIudDlb8Jz2Am6VzOOkpkZoanxo="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg=="
     },
     "string_decoder": {
       "version": "1.3.0",
@@ -23418,7 +23347,8 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz",
       "integrity": "sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "supports-color": {
       "version": "7.2.0",
@@ -24193,7 +24123,8 @@
       "version": "7.5.5",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.5.tgz",
       "integrity": "sha512-BAkMFcAzl8as1G/hArkxOxq3G7pjUqQ3gzYbLL0/5zNkph70e+lCoxBGnm6AW1+/aiNeV4fnKqZ8m4GZewmH2w==",
-      "dev": true
+      "dev": true,
+      "requires": {}
     },
     "xdg-basedir": {
       "version": "4.0.0",
@@ -24286,7 +24217,8 @@
     "zustand": {
       "version": "3.5.12",
       "resolved": "https://registry.npmjs.org/zustand/-/zustand-3.5.12.tgz",
-      "integrity": "sha512-Cv9fX/yM5HXYODkn3Q/HMmMofnmZw3yqM73VT/3rQEvI/04Yl0OFNO24qMofhN82xTPWcCffkGPFCMq8r67Whg=="
+      "integrity": "sha512-Cv9fX/yM5HXYODkn3Q/HMmMofnmZw3yqM73VT/3rQEvI/04Yl0OFNO24qMofhN82xTPWcCffkGPFCMq8r67Whg==",
+      "requires": {}
     }
   }
 }

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "next-runtime",
   "description": "handler to improve data handling in Next.js getServerSideProps",
   "author": "Stephan Meijer <stephan@meijer.ws>",
-  "version": "2.4.2",
+  "version": "2.4.1",
   "private": false,
   "keywords": [
     "nextjs",

--- a/package.json
+++ b/package.json
@@ -2,9 +2,13 @@
   "name": "next-runtime",
   "description": "handler to improve data handling in Next.js getServerSideProps",
   "author": "Stephan Meijer <stephan@meijer.ws>",
-  "version": "2.4.1",
+  "version": "2.4.2",
   "private": false,
-  "keywords": ["nextjs", "api", "forms"],
+  "keywords": [
+    "nextjs",
+    "api",
+    "forms"
+  ],
   "repository": "https://github.com/smeijer/next-runtime",
   "homepage": "https://next-runtime.meijer.ws",
   "scripts": {
@@ -32,7 +36,7 @@
   "dependencies": {
     "@types/accepts": "^1",
     "@types/body-parser": "^1",
-    "@types/busboy": "^0.2",
+    "@types/busboy": "^1.5.4",
     "@types/bytes": "^3",
     "@types/cookies": "^0.7",
     "@types/debug": "^4",
@@ -42,7 +46,7 @@
     "accepts": "^1.3.7",
     "attr-accept": "^2.2.2",
     "body-parser": "^1.19.0",
-    "busboy": "^0.2.14",
+    "busboy": "^1.6.0",
     "bytes": "^3.1.0",
     "cookies": "^0.8.0",
     "debug": "^2.6.9",
@@ -56,7 +60,6 @@
     "@testing-library/react": "^12.1.0",
     "@testing-library/user-event": "^13.2.1",
     "@types/accepts": "^1.3.5",
-    "@types/busboy": "^0.2.4",
     "@types/bytes": "^3.1.1",
     "@types/cookies": "^0.7.7",
     "@types/cors": "^2.8.12",

--- a/src/handle.test.ts
+++ b/src/handle.test.ts
@@ -185,6 +185,18 @@ test('handles field size limit', async () => {
   const data = new FormData();
   data.append('name', 'abcdef'); // longer than 5
 
+  const response = await fetch('/', {
+    method: 'POST',
+    headers: data.getHeaders(),
+    body: data,
+  });
+
+  expect(response.body).toEqual({
+    errors: [
+      { name: 'FIELD_SIZE_EXCEEDED', message: 'field "name" exceeds 5B' },
+    ],
+  });
+
   const jsonResponse = await fetch('/', {
     method: 'POST',
     body: { name: 'abcdef' },

--- a/src/handle.test.ts
+++ b/src/handle.test.ts
@@ -185,18 +185,6 @@ test('handles field size limit', async () => {
   const data = new FormData();
   data.append('name', 'abcdef'); // longer than 5
 
-  const response = await fetch('/', {
-    method: 'POST',
-    headers: data.getHeaders(),
-    body: data,
-  });
-
-  expect(response.body).toEqual({
-    errors: [
-      { name: 'FIELD_SIZE_EXCEEDED', message: 'field "name" exceeds 5B' },
-    ],
-  });
-
   const jsonResponse = await fetch('/', {
     method: 'POST',
     body: { name: 'abcdef' },

--- a/src/runtime/body-parser.ts
+++ b/src/runtime/body-parser.ts
@@ -1,6 +1,6 @@
 import accepts from 'attr-accept';
 import bodyParser from 'body-parser';
-import Busboy from 'busboy';
+import createBusboy from 'busboy';
 import bytes from 'bytes';
 import fs from 'fs';
 import { IncomingMessage, ServerResponse } from 'http';
@@ -139,7 +139,7 @@ export async function bodyparser<TData extends Record<string, unknown>>(
 
   // busboy handles application/x-www-form-urlencoded and multipart/form-data,
   return new Promise((resolve, reject) => {
-    const busboy = Busboy({
+    const busboy = createBusboy({
       headers: req.headers,
       limits: {
         files: maxFileCount,
@@ -152,79 +152,65 @@ export async function bodyparser<TData extends Record<string, unknown>>(
 
     // We don't want to have these heavy ops when the developer didn't think of it.
     if (maxFileCount || options?.uploadDir || options?.onFile) {
-      busboy.on(
-        'file',
-        async (
-          field: string,
-          file: NodeJS.ReadableStream,
-          name: any,
-          encoding: any,
-          type: any,
-        ) => {
-          const value: File = { name, type, size: 0 };
+      busboy.on('file', async (field, file, info) => {
+        const value: File = {
+          name: info.filename,
+          type: info.mimeType,
+          size: 0,
+        };
 
-          // skip empty fields
-          if (!value.name) return file.resume();
+        // skip empty fields
+        if (!value.name) return file.resume();
 
-          const fileInfo = JSON.parse(JSON.stringify(value.name));
-
-          if (limits.mimeType && !accepts({ name, type }, limits.mimeType)) {
-            errors.push({
-              name: 'FILE_TYPE_REJECTED',
-              message: `file "${fileInfo.filename}" is not of type "${limits.mimeType}"`,
-            });
-            return file.resume();
-          }
-
-          if (options?.onFile) {
-            options.onFile({ field, file: value, stream: file });
-          } else {
-            // write to disk when the user doesn't provide an onFile handler
-            await fs.promises.mkdir(uploadDir, { recursive: true });
-            value.path = path.join(
-              uploadDir,
-              path.basename(field) + '_' + picoid(17),
-            );
-            file.pipe(fs.createWriteStream(value.path));
-          }
-
-          file.on('data', (data: string | any[]) => {
-            value.size = data.length;
+        if (limits.mimeType && !accepts(value, limits.mimeType)) {
+          errors.push({
+            name: 'FILE_TYPE_REJECTED',
+            message: `file "${value.name}" is not of type "${limits.mimeType}"`,
           });
-
-          file.on('end', async () => {
-            if ((file as any).truncated) {
-              return errors.push({
-                name: 'FILE_SIZE_EXCEEDED',
-                message: `file "${fileInfo.filename}" exceeds ${bytes(
-                  maxFileSize || 0,
-                )}`,
-              });
-            }
-
-            return setField(data, field, value);
-          });
-        },
-      );
-    }
-
-    busboy.on(
-      'field',
-      function (field: any, value: unknown, _: any, truncated: any) {
-        if (truncated) {
-          const errorMessage = `field "${field}" exceeds ${bytes(
-            maxFieldSize || 0,
-          )}`;
-
-          return errors.push({
-            name: 'FIELD_SIZE_EXCEEDED',
-            message: errorMessage,
-          });
+          return file.resume();
         }
 
-        setField(data, field, value);
-      },
-    );
+        if (options?.onFile) {
+          options.onFile({ field, file: value, stream: file });
+        } else {
+          // write to disk when the user doesn't provide an onFile handler
+          await fs.promises.mkdir(uploadDir, { recursive: true });
+          value.path = path.join(
+            uploadDir,
+            path.basename(field) + '_' + picoid(17),
+          );
+          file.pipe(fs.createWriteStream(value.path));
+        }
+
+        file.on('data', (data) => {
+          value.size = data.length;
+        });
+
+        file.on('end', async () => {
+          if ((file as any).truncated) {
+            return errors.push({
+              name: 'FILE_SIZE_EXCEEDED',
+              message: `file "${value.name}" exceeds ${bytes(
+                maxFileSize || 0,
+              )}`,
+            });
+          }
+
+          return setField(data, field, value);
+        });
+      });
+    }
+
+    busboy.on('field', function (field, value, info) {
+      if (info.nameTruncated || info.valueTruncated) {
+        return errors.push({
+          name: 'FIELD_SIZE_EXCEEDED',
+          message: `field "${field}" exceeds ${bytes(maxFieldSize || 0)}`,
+        });
+      }
+
+      setField(data, field, value);
+    });
 
     busboy.on('filesLimit', () => {
       errors.push({

--- a/tsconfig.build.json
+++ b/tsconfig.build.json
@@ -16,7 +16,8 @@
     "isolatedModules": true,
     "jsx": "react-jsx",
     "sourceMap": true,
-    "declaration": true
+    "declaration": true,
+    "noImplicitAny": false
   },
   "include": ["next-env.d.ts", "jest.d.ts", "./src/**/*"],
   "exclude": ["node_modules", "**/*.test.*"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -18,7 +18,8 @@
     "sourceMap": true,
     "declaration": true,
     "noEmit": true,
-    "incremental": true
+    "incremental": true,
+    "noImplicitAny": false
   },
   // TODO: utils is not published
   "include": ["next-env.d.ts", "jest.d.ts", "./src/**/*", "./pages/**/*"],


### PR DESCRIPTION
Fix: I have come across one dependency issue of package dicer

I have came across that latest busboy package is no longer using the dicer package.

So I have updated the dependencies and bit of code change to support the formats and error push methods.

(to make sure unit test is passing)