### PR TITLE
fix: specify type declaration in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "typecheck": "tsc --noEmit"
   },
   "main": "./index.js",
+  "types": "./lib/index.d.ts",
   "source": "./src/index.ts",
   "license": "MIT",
   "__exports": {


### PR DESCRIPTION
The TypeScript compiler gives an error when importing `next-runtime`:
```
Cannot find module 'next-runtime' or its corresponding type declarations.ts(2307)
```

The automated CI releases publishes all the code with the `lib/` folder now.
Therefore, the location of `index.d.ts` file has changed to `lib/index.d.ts`
https://www.npmjs.com/package/next-runtime/v/2.4.3?activeTab=code 

The PR adds the path of type declaration file in `package.json` so TypeScript can detect it.

Preferably, we should only publish JavaScript files. 
We could do that by [whitelisting only the `lib/` folder](https://docs.npmjs.com/cli/v11/configuring-npm/package-json#files
) in `package.json`

So also adding:
```json
  "files": ["lib/"],
```


I am happy to make that change as well unless you have other suggested ways to do it.